### PR TITLE
Add spaces to prevent extraneous <p> tags.

### DIFF
--- a/plugin/tiddlers/window.tid
+++ b/plugin/tiddlers/window.tid
@@ -1,7 +1,6 @@
 title: $:/plugins/EvidentlyCube/AutoComplete/window
 tags: $:/tags/PageTemplate
 
-\whitespace trim
 <$let
 	window-id={{{ [<tw-window-id>else[]] }}}
 	count={{{ [list[$:/temp/AutoComplete/completion-data]count[]] }}}
@@ -12,6 +11,7 @@ tags: $:/tags/PageTemplate
 	selected={{$:/temp/AutoComplete/completion-data!!index}}
 	offset={{{ [<selected>subtract<half-limit>min<max-offset>max[0]] }}}
 >
+
 <$list filter="""
 [{$:/temp/AutoComplete/completion-data!!show}]
 =[{$:/temp/AutoComplete/completion-data!!show-window}match<tv-window-id>then[1]]
@@ -20,27 +20,41 @@ tags: $:/tags/PageTemplate
 """ variable="ignore">
 
 <ul class="ec_ac-completion" style={{$:/temp/AutoComplete/completion-data!!style}}>
+
 	<$list filter="[<offset>compare:number:gt[0]]">
 		<li class="ec_ac-dots-top">...</li>
 	</$list>
+
 	<$list
 		filter="[list[$:/temp/AutoComplete/completion-data]rest<offset>first<limit>]"
 		counter="index"
 		emptyMessage="""<li class="label">No results</li>"""
 	>
+
 		<$list filter="[<index>add<offset>match<selected>]" variable="_" emptyMessage="""
 			<li class="ec_ac-link" data-value=<<currentTiddler>>>
 				<$text text={{{ [<currentTiddler>subfilter{$:/temp/AutoComplete/completion-data!!display-filter}] }}} />
 			</li>
 		""">
+
 			<li class="ec_ac-link selected" data-value=<<currentTiddler>>>
+
 				<$text text={{{ [<currentTiddler>subfilter{$:/temp/AutoComplete/completion-data!!display-filter}] }}} />
+
 			</li>
+
 		</$list>
+
 	</$list>
+
 	<$list filter="[<offset>compare:number:lt<max-offset>]">
+
 		<li class="ec_ac-dots-bottom">...</li>
+
 	</$list>
+
 </ul>
+
 </$list>
+
 </$let>


### PR DESCRIPTION
I'm working on an alternate layout for my TiddlyWiki, and I noticed an extra `<p></p>` was in the page templates. After narrowing it down, I figured out it was your awesome AutoComplete plugin.

I don't know why it does this, but adding **extra** spaces makes TW **not** generate `<p>`s around things. ¯\_(ツ)_/¯